### PR TITLE
Add python_requires to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,6 +102,9 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['native', 'docs', 'test', 'dist', 'build']),
     ext_modules=extensions,
     include_dirs=[np.get_include()],
+    
+    # See https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires='~=3.6',
 
     # See https://packaging.python.org/en/latest/requirements.html
     install_requires=[


### PR DESCRIPTION
It is nice to call out the supported Python versions in setup.py, even though this is well documented in the README and the `setup.py` fails straightaway in Python <=3.5 because of the Python 3.6+ string formatting syntax. 